### PR TITLE
[CCI-4027] Add Custom Lifecycle Hook Parameters in Autoscaling Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,11 @@ An auto scaling policy consists of predefined rules and parameters that dictate 
             "minNodes": number,
             "maxNodes": number
         }
-    ]
+    ],
+    "customLifecycleHookParams": {
+        "defaultResult": "CONTINUE" or "ABANDON",
+        "heartbeatTimeout": number between [30, 7200] 
+    }
 }
 ```
 

--- a/source/lib/constructs/druidAutoScalingGroup.ts
+++ b/source/lib/constructs/druidAutoScalingGroup.ts
@@ -36,6 +36,7 @@ export interface DruidAutoScalingGroupProps {
     readonly serviceTier?: string;
     readonly brokerTiers?: string[];
     readonly baseUrl: string;
+    readonly customLifecycleHookParams?: CustomLifecycleHookParams;
 }
 
 // Shared context parameters across all auto scaling groups
@@ -49,6 +50,11 @@ export interface DruidAutoScalingGroupContext {
     readonly customAmi?: CustomAmi;
     readonly solutionVersion: string;
     readonly tlsCertificateSecretName: string;
+}
+
+export interface CustomLifecycleHookParams {
+    readonly defaultResult?: as.DefaultResult;
+    readonly heartbeatTimeout?: number;
 }
 
 //Creates Launch Template for EC2 and Autoscaling group for different druid process Types
@@ -120,7 +126,8 @@ export class DruidAutoScalingGroup extends Construct {
             asg,
             props.nodeType,
             nodeTierName,
-            this.gracefulTerminationParam
+            this.gracefulTerminationParam,
+            props.customLifecycleHookParams
         );
 
         this.autoScalingGroup = asg;
@@ -131,15 +138,16 @@ export class DruidAutoScalingGroup extends Construct {
         asg: as.IAutoScalingGroup,
         nodeType: DruidNodeType,
         nodeTierName: string,
-        gracefulTerminationParam: ssm.IStringParameter
+        gracefulTerminationParam: ssm.IStringParameter,
+        customLifecycleHookParams?: CustomLifecycleHookParams
     ): void {
         // using prettier-ignore prevents prettier from reformatting the nosonar line to the next line
         // prettier-ignore
         new as.CfnLifecycleHook(this, 'lifecycle-termination', { // NOSONAR (typescript:S1848) - cdk construct is used
             autoScalingGroupName: asg.autoScalingGroupName,
             lifecycleTransition: as.LifecycleTransition.INSTANCE_TERMINATING,
-            defaultResult: as.DefaultResult.CONTINUE,
-            heartbeatTimeout: INSTANCE_TERMINATION_TIMEOUT,
+            defaultResult: customLifecycleHookParams?.defaultResult ?? as.DefaultResult.CONTINUE,
+            heartbeatTimeout: customLifecycleHookParams?.heartbeatTimeout ?? INSTANCE_TERMINATION_TIMEOUT,
         });
 
         // prettier-ignore

--- a/source/lib/stacks/druidEc2Stack.ts
+++ b/source/lib/stacks/druidEc2Stack.ts
@@ -23,6 +23,7 @@ import {
     DEFAULT_TIER,
     DRUID_METRICS_NAMESPACE,
     DRUID_SECURITY_GROUP_NAME,
+    INSTANCE_TERMINATION_TIMEOUT,
 } from '../utils/constants';
 import {
     AutoScalingPolicy,
@@ -36,6 +37,7 @@ import {
     addCfnNagSuppression,
 } from '../constructs/cfnNagSuppression';
 import {
+    CustomLifecycleHookParams,
     DruidAutoScalingGroup,
     DruidAutoScalingGroupContext,
 } from '../constructs/druidAutoScalingGroup';
@@ -226,7 +228,8 @@ export class DruidEc2Stack extends DruidStack {
         });
 
         // create master asg
-        const masterAsg = this.createAutoScalingGroup(asgContext, DruidNodeType.MASTER);
+        const masterAsg = this.createMasterASG(asgContext);
+
         queryAsgList.forEach((queryAsg) => {
             masterAsg.autoScalingGroup.node.addDependency(queryAsg.autoScalingGroup);
         });
@@ -286,6 +289,25 @@ export class DruidEc2Stack extends DruidStack {
         });
     }
 
+    private createCustomLifecycleHookParams(autoScalingPolicy?: AutoScalingPolicy): CustomLifecycleHookParams | undefined {
+        return autoScalingPolicy?.customLifecycleHookParams ? {
+            defaultResult: autoScalingPolicy.customLifecycleHookParams.defaultResult as autoscaling.DefaultResult ?? autoscaling.DefaultResult.CONTINUE,
+            heartbeatTimeout: autoScalingPolicy.customLifecycleHookParams.heartbeatTimeout ?? INSTANCE_TERMINATION_TIMEOUT,
+        } : undefined;
+    }
+
+    private createMasterASG(
+        asgContext: DruidAutoScalingGroupContext,
+    ): DruidAutoScalingGroup {
+        const druidConfig = asgContext.clusterParams.hostingConfig as Ec2Config;
+        const autoScalingPolicy = druidConfig['master']?.autoScalingPolicy;
+        const customLifecycleHookParams = this.createCustomLifecycleHookParams(autoScalingPolicy);
+
+        const masterAsg = this.createAutoScalingGroup(asgContext, DruidNodeType.MASTER, undefined, undefined, customLifecycleHookParams);
+
+        return masterAsg;
+    }
+
     private createQueryASG(
         asgContext: DruidAutoScalingGroupContext,
         queryTargetGrp: elb.IApplicationTargetGroup,
@@ -294,11 +316,14 @@ export class DruidEc2Stack extends DruidStack {
         autoScalingPolicy?: AutoScalingPolicy
     ): DruidAutoScalingGroup {
         const queryTierName = utils.getNodeTierName(DruidNodeType.QUERY, serviceTier);
+        const customLifecycleHookParams = this.createCustomLifecycleHookParams(autoScalingPolicy);
+
         const queryAsg = this.createAutoScalingGroup(
             asgContext,
             DruidNodeType.QUERY,
             serviceTier,
-            brokerTiers
+            brokerTiers,
+            customLifecycleHookParams
         );
 
         queryAsg.autoScalingGroup.attachToApplicationTargetGroup(queryTargetGrp);
@@ -336,10 +361,14 @@ export class DruidEc2Stack extends DruidStack {
         autoScalingPolicy?: AutoScalingPolicy
     ): DruidAutoScalingGroup {
         const dataTierName = utils.getNodeTierName(DruidNodeType.DATA, serviceTier);
+        const customLifecycleHookParams = this.createCustomLifecycleHookParams(autoScalingPolicy);
+
         const dataAsg = this.createAutoScalingGroup(
             asgContext,
             DruidNodeType.DATA,
-            serviceTier
+            serviceTier,
+            undefined,
+            customLifecycleHookParams
         );
 
         if (autoScalingPolicy?.cpuUtilisationPercent) {
@@ -422,10 +451,14 @@ export class DruidEc2Stack extends DruidStack {
             DruidNodeType.MIDDLE_MANAGER,
             serviceTier
         );
+        const customLifecycleHookParams = this.createCustomLifecycleHookParams(autoScalingPolicy);
+
         const middleManagerAsg = this.createAutoScalingGroup(
             asgContext,
             DruidNodeType.MIDDLE_MANAGER,
-            serviceTier
+            serviceTier,
+            undefined,
+            customLifecycleHookParams
         );
 
         if (autoScalingPolicy?.cpuUtilisationPercent) {
@@ -475,10 +508,14 @@ export class DruidEc2Stack extends DruidStack {
             DruidNodeType.HISTORICAL,
             serviceTier
         );
+        const customLifecycleHookParams = this.createCustomLifecycleHookParams(autoScalingPolicy);
+
         const historicalAsg = this.createAutoScalingGroup(
             asgContext,
             DruidNodeType.HISTORICAL,
-            serviceTier
+            serviceTier,
+            undefined,
+            customLifecycleHookParams
         );
 
         if (autoScalingPolicy?.cpuUtilisationPercent) {
@@ -696,7 +733,8 @@ export class DruidEc2Stack extends DruidStack {
         asgContext: DruidAutoScalingGroupContext,
         nodeType: DruidNodeType,
         serviceTier?: string,
-        brokerTiers?: string[]
+        brokerTiers?: string[],
+        customLifecycleHookParams?: CustomLifecycleHookParams,
     ): DruidAutoScalingGroup {
         const nodeTierName = utils.getNodeTierName(nodeType, serviceTier);
 
@@ -709,6 +747,7 @@ export class DruidEc2Stack extends DruidStack {
                 serviceTier,
                 brokerTiers,
                 baseUrl: this.druidBaseUrl,
+                customLifecycleHookParams,
             }
         );
 

--- a/source/lib/utils/types.ts
+++ b/source/lib/utils/types.ts
@@ -9,6 +9,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { ComparisonOperator, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
 
 import { ScalingInterval } from 'aws-cdk-lib/aws-applicationautoscaling';
+import { CustomLifecycleHookParams } from '../constructs/druidAutoScalingGroup';
 
 export enum DruidProcessType {
     COORDINATOR = 'coordinator',
@@ -286,6 +287,7 @@ export interface AutoScalingPolicy {
         startTime?: string;
         endTime?: string;
     }[];
+    customLifecycleHookParams?: CustomLifecycleHookParams;
 }
 
 export interface OidcIdpConfig {


### PR DESCRIPTION
## Description of changes
Adds the ability to provide custom lifecycle hook parameters for each individual autoscaling group

## Why this is needed
This is necessary because we want to be able to scale specific tier of nodes but we don't want to kill the node if it has a task that is taking longer than 7200 seconds to send it's lifecycle state as being ready to be taken down so we want to allow the autoscaling to abandon the update to give the node the chance to finish its work.

We however do not want the update to be the default for all ASGs so we want this to be customizable per ASG and if it's not overridden in the CDK then the default behavior is used.
