### PR TITLE
add dom to tsconfig lib

### DIFF
--- a/source/tsconfig.json
+++ b/source/tsconfig.json
@@ -5,8 +5,7 @@
     "module": "commonjs",
     "lib": [
       "es2018",
-      "dom",
-      "es6"
+      "dom"
     ],
     "declaration": true,
     "strict": true,

--- a/source/tsconfig.json
+++ b/source/tsconfig.json
@@ -4,7 +4,9 @@
     "target": "ES2018",
     "module": "commonjs",
     "lib": [
-      "es2018"
+      "es2018",
+      "dom",
+      "es6"
     ],
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add `dom` to lib section in `tsconfig.json`. Fixing this error -> `node_modules/axios/index.d.ts(364,23): error TS2304: Cannot find name 'RequestInit'.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
